### PR TITLE
Add GoCardless database migration post mortem

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Sun/Oracle. Sun famously didn't include ECC in a couple generations of server pa
 
 [CircleCI](http://status.circleci.com/incidents/hr0mm9xmm3x6). A github outage and recovery caused an unexpectedly large incoming load. For reasons that aren't specified, a large load causes CircleCI's queue system to slow down, in this case to handling one transaction per minute.
 
+[GoCardless](https://gocardless.com/blog/zero-downtime-postgres-migrations-the-hard-parts/). All queries on a critical PostgreSQL table were blocked by the combination of an extremely fast database migration and a long-running read query, causing 15 seconds of downtime.
+
 Unfortunately, most of the interesting post-mortems I know about are locked inside confidential pages at Google and Microsoft. Please add more links if you know of any interesting public post mortems! [This](https://plus.google.com/communities/115136140203018391796) is a pretty good resource; other links to collections of post mortems are also appreciated.
 
 ## Contributors


### PR DESCRIPTION
https://gocardless.com/blog/zero-downtime-postgres-migrations-the-hard-parts/

(This is really a post mortem of 15 seconds of downtime we had thanks to a routine database migration interacting with a long-running query.)