### PR TITLE
New website in the list of postmortems

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Unfortunately, most of the interesting post-mortems I know about are locked insi
 
 [Wikimedia's postmortems](https://wikitech.wikimedia.org/wiki/Incident_documentation).
 
+[Availability Digest website](http://www.availabilitydigest.com/articles.htm)
 
 
 ## Contributors
@@ -102,4 +103,5 @@ Unfortunately, most of the interesting post-mortems I know about are locked insi
 * Ahmet Alp Balkan
 * Jason Dusek
 * Vincent Ambo
+* Luan Cestari
 


### PR DESCRIPTION
Added Availability Digest that have a collection of postmortems.

A suggestion that I also have is to use a static web page generator (such as http://jekyllrb.com/ which can be hosted in github pages or any of the https://www.staticgen.com/ ) to create a better interface for the collection of postmortems, especially have tags to sort the different kind of failures for someone who is looking for something around an specific kind of outage root cause, for example. 

Also, I not sure if I can suggest any kind of post mortem, like this one https://blogs.dropbox.com/tech/2014/01/outage-post-mortem/ or https://blog.cloudflare.com/todays-outage-post-mortem-82515/ . Maybe, if this list start to grow a lot, it would be nice to have a  CONTRIBUTING.md file (more information https://github.com/blog/1184-contributing-guidelines )