### PR TITLE
Add BrowserStack Breach from 11/9/2014

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Sun/Oracle. Sun famously didn't include ECC in a couple generations of server pa
 
 [Spotify](https://labs.spotify.com/2013/06/04/incident-management-at-spotify/). Lack of exponential backoff in a microservice caused a cascading failure, leading to notable service degradation.
 
+[BrowserStack](https://www.browserstack.com/attack-and-downtime-on-9-November). An old prototype machine with the [Shellshock](https://en.wikipedia.org/wiki/Shellshock_(software_bug)) vulnerability still active had secret keys on it which ultimately led to a security breach of the Production system.
+
 Unfortunately, most of the interesting post-mortems I know about are locked inside confidential pages at Google and Microsoft. Please add more links if you know of any interesting public post mortems!  is a pretty good resource; other links to collections of post mortems are also appreciated.
 
 ## Other lists of postmortems


### PR DESCRIPTION
This adds the BrowserStack post-mortem from their breach on 11/9/2014. I think it is a good example of how hardcoded keys with elevated privileges are a bad thing and also a great write-up and actions list.