### PR TITLE
Add Sentry 2016-06-14 post-mortem

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ A List of Post-mortems!
 
 [Stack Overflow](http://stackstatus.net/post/96025967369/outage-post-mortem-august-25th-2014). A bad firewall config blocked stackexchange/stackoverflow.
 
+[Sentry](http://blog.getsentry.com/2016/06/14/security-incident-june-12-2016.html). Wrong Amazon S3 settings on backups lead to data leak.
+
 [TravisCI](https://www.traviscistatus.com/incidents/khzk8bg4p9sy). A configuration issue (incomplete password rotation) led to "leaking" VMs, leading to elevated build queue times.
 
 [Valve](https://blog.thousandeyes.com/steam-outage-monitor-data-center-connectivity/). Although there's no official postmortem, it looks like a bad BGP config severed Valve's connection to Level 3, Telia, and Abovenet/Zayo, which resulted in a global Steam outage.


### PR DESCRIPTION
The blog post describes the security incident about one of their S3 buckets for backup had incorrect permissions.