### PR TITLE
Add Travis CI stable GCE VM image deletion from 2016-08-09 (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ A List of Post-mortems!
 
 [TravisCI](https://www.traviscistatus.com/incidents/khzk8bg4p9sy). A configuration issue (incomplete password rotation) led to "leaking" VMs, leading to elevated build queue times.
 
+[TravisCI](https://blog.travis-ci.com/2016-09-30-the-day-we-deleted-our-vm-images/). A configuration issue (automated age-based Google Compute Engine VM image cleanup job) caused stable base VM images to be deleted.
+
 [Valve](https://blog.thousandeyes.com/steam-outage-monitor-data-center-connectivity/). Although there's no official postmortem, it looks like a bad BGP config severed Valve's connection to Level 3, Telia, and Abovenet/Zayo, which resulted in a global Steam outage.
 
 


### PR DESCRIPTION
From http://twitter.com/travisci/status/781916036274741250 , retweeted into my timeline by @emdantrim.