### PR TITLE
Change README.md to work with new Markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A List of Post-mortems!
 
 <br/><br/>
 
-##Table of Contents
+## Table of Contents
 
 **[Config Errors](#config-errors)**
 


### PR DESCRIPTION
As of March 14, 2017 Github [changed their specs for Github-flavored Markdown](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown). This leads to us needing to add spaces between pound signs and the heading text. This PR fixes the style.

Cheers