### PR TITLE
Add Google Cloud Storage incident #19002

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ A List of Post-mortems!
 
 [Valve](https://blog.thousandeyes.com/steam-outage-monitor-data-center-connectivity/). Although there's no official postmortem, it looks like a bad BGP config severed Valve's connection to Level 3, Telia, and Abovenet/Zayo, which resulted in a global Steam outage.
 
+[Google](https://status.cloud.google.com/incident/storage/19002). A configuration change intended to address an uptick in demand for metadata storage, which overloaded part of the blob lookup system, which caused a cascading failure with user-visible service impact to Gmail, Google Photos, Google Drive, and other GCP services dependent on blob storage.
+
 
 ## Hardware/Power Failures
 


### PR DESCRIPTION
2019-03-12T18:40-08:00 -> 2019-03-12T22:50-08:00 (US/Pacific)

cf. also https://status.cloud.google.com/incident/appengine/19007 ,
a separate incident report about the impact to Google App Engine
service stemming from the same GCS incident