### PR TITLE
Replace link to G+ Community with new community

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@
 
 [Availability Digest website](http://www.availabilitydigest.com/articles.htm).
 
-[Google+ postmortems community](https://plus.google.com/communities/115136140203018391796).
+[Postmortems community](https://postmortems.info) (with imported archive from the now-dead G+ community).
 
 [John Daily's list of postmortems (in json)](https://github.com/macintux/Service-postmortems).
 


### PR DESCRIPTION
Gplus aka googleplus has been closed. Some posts can be found in the Internet Archive. Although some Communities can also be found there, one sees only a truncated listing. Chris Jones has set up a new community and imported the posts and comments.