### PR TITLE
search README.md for broken links

### DIFF
--- a/.github/workflows/notfound.yml
+++ b/.github/workflows/notfound.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Fix links
-        uses: tmcw/notfoundbot@v2.1.0
+        uses: tmcw/notfoundbot@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          content-folder: .


### PR DESCRIPTION
tmcw/notfoundbot only searches in the configured `content-folder` - but
README.md is in the root directory, hence it was never searched.

This now upgrades tmcw/notfoundbot from 2.1.0 to 2.2.0, which is the
current version and required to use the `content-folder` input, and
configures it to search the entire root folder of the repo.