### PR TITLE
update link of  github core service outage report (Nov 27 2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
 
 [Knight Capital](https://dougseven.com/2014/04/17/knightmare-a-devops-cautionary-tale/). A combination of conflicting deployed versions and re-using a previously used bit caused a $460M loss.
 
-[WebKit code repository](https://blogs.collab.net/subversion/subversion-sha1-collision-problem-statement-prevention-remediation-options). The WebKit repository, a Subversion repository configured to use deduplication, became unavailable after two files with the same SHA-1 hash were checked in as test data, with the intention of implementing a safety check for collisions. The two files had different md5 sums and so a checkout would fail a consistency check. For context, the first public SHA-1 hash collision had very recently been announced, with an example of two colliding files.
+[WebKit code repository](https://digital.ai/catalyst-blog/subversion-sha1-collision-problem-statement-prevention-and-remediation-options). The WebKit repository, a Subversion repository configured to use deduplication, became unavailable after two files with the same SHA-1 hash were checked in as test data, with the intention of implementing a safety check for collisions. The two files had different md5 sums and so a checkout would fail a consistency check. For context, the first public SHA-1 hash collision had very recently been announced, with an example of two colliding files.
 
 ## Time
 


### PR DESCRIPTION
The old link doesn't work any more and is stopping people from submitting new PRs