### PR TITLE
Add note about inclusion in the VOID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # A List of Post-mortems!
 
+> This list of post-mortems has been included in the Verica Open Incident
+> Database (https://www.thevoid.community/) if you wish to browse them there.
+
 ## Table of Contents
 
  - **[Config Errors](#config-errors)**


### PR DESCRIPTION
The VOID has included all the post-mortems from this list, including
many others.

Anyone visiting this list would probably benefit from knowing about the
VOID, so add a note to help them find it.